### PR TITLE
Update CICD pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,8 @@ jobs:
         echo "${{ secrets.CICD_SSH_KEY }}" > ~/.ssh/id_rsa
         chmod -R 700 ~/.ssh
     - name: Rsync deployment
+      env:
+        REMOTE_DIRECTORY: /var/www/mayaal-design
       run: |
         rsync \
           -avz \
@@ -24,4 +26,4 @@ jobs:
           --exclude '.github' \
           -e ssh \
           --delete . \
-          ${{ secrets.CICD_SSH_USER }}@${{ secrets.CICD_SSH_HOST}}:/var/www/mayaal-design
+          ${{ secrets.CICD_SSH_USER }}@${{ secrets.CICD_SSH_HOST}}:${{ env.REMOTE_DIRECTORY }}


### PR DESCRIPTION
This PR updates the CICD pipeline.

Detailed changes:

- Update Github *checkout* action to version 4, due to deprecation of version 3.
- Make the deployment command multiline to allow for better readability.
- Exclude `.git` and `.github` directories from deployment.
- Move the remote directory to a job-based environment variable.